### PR TITLE
refactor: remove anotation redundant

### DIFF
--- a/src/main/java/com/api/relivro/model/UserModel.java
+++ b/src/main/java/com/api/relivro/model/UserModel.java
@@ -7,7 +7,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
-import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,7 +16,6 @@ import java.time.YearMonth;
 
 @Data
 @Entity(name = "user")
-@Table(name = "\"user\"")
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserModel {


### PR DESCRIPTION
Removi a anotação `@Table` que estava redundante, pois ele estava com o mesmo nome que a entidade definido no `@Entity`. A anotação `@Table` por padrão já pega o mesmo nome da entidade.